### PR TITLE
Override the class list via TaxonomyModelTF.from_config()

### DIFF
--- a/chirp/inference/models.py
+++ b/chirp/inference/models.py
@@ -310,14 +310,17 @@ class TaxonomyModelTF(interface.EmbeddingModel):
       label_csv_path = base_path / 'label.csv'
 
     model = tf.saved_model.load(model_path)
-    with label_csv_path.open('r') as f:
-      class_list = namespace.ClassList.from_csv(f)
+
+    if hasattr(config, 'class_list') and config.class_list is not None:
+      # Config brings its own class list
+      pass
+    else:
+      with label_csv_path.open('r') as f:
+        config.class_list = namespace.ClassList.from_csv(f)
 
     # Check whether the model support polymorphic batch shape.
     batchable = cls.is_batchable(model)
-    return cls(
-        model=model, class_list=class_list, batchable=batchable, **config
-    )
+    return cls(model=model, batchable=batchable, **config)
 
   def embed(self, audio_array: np.ndarray) -> interface.InferenceOutputs:
     if self.batchable:


### PR DESCRIPTION
### Context

Sometimes we deal with SavedModels (not built by us) where the class list is not in "labels.csv" but in some other file.  In those cases, inference via the SDK's `TaxonomyModelTF` will fail because the number of shape of output logits does not match the class_list shape.

### What I changed

This PR allows downstream users to override the `TaxonomyModelTF.class_list` when instantiating using the `from_config` factory method.

My downstream code uses it as follows:
```py
    perch_cfg = ConfigDict()
    perch_cfg.model_path = model_path
    with open(model_path / "reef_label.csv", "r") as f:
        perch_cfg.class_list = namespace.ClassList.from_csv(f)

    model = TaxonomyModelTF.from_config(perch_cfg)
```


