### PR TITLE
write to parquet

### DIFF
--- a/chirp/inference/classify/classify.py
+++ b/chirp/inference/classify/classify.py
@@ -183,7 +183,7 @@ def get_inference_dataset(
   )
   return inference_ds
 
-def flush_rows(
+def flush_inference_rows(
   output_path: epath.Path, 
   shard_num: int, 
   rows: list[dict[str, str]],
@@ -239,7 +239,6 @@ def write_inference_file(
   detection_count = 0
   nondetection_count = 0
   headers = ['filename', 'timestamp_s', 'label', 'logit']
-  # Write column headers if CSV format
   for ex in tqdm.tqdm(inference_ds.as_numpy_iterator()):
     for t in range(ex['logits'].shape[0]):
       for i, label in enumerate(labels):
@@ -258,13 +257,13 @@ def write_inference_file(
           }
           rows.append(row)
           if len(rows) >= shard_size:
-            flush_rows(output_filepath, shard_num, rows, format, headers)
+            flush_inference_rows(output_filepath, shard_num, rows, format, headers)
             rows = []
             shard_num += 1
           detection_count += 1
         else:
           nondetection_count += 1
   # write remaining rows
-  flush_rows(output_filepath, shard_num, rows, format, headers)
+  flush_inference_rows(output_filepath, shard_num, rows, format, headers)
   print('\n\n\n   Detection count: ', detection_count)
   print('NonDetection count: ', nondetection_count)

--- a/chirp/inference/classify/classify.py
+++ b/chirp/inference/classify/classify.py
@@ -205,10 +205,15 @@ def write_inference_file(
       output_filepath = output_filepath[:-4]
     if not output_filepath.endswith('.parquet'):
       output_filepath += '.parquet'
-    
-    parquet_count = 0
     os.mkdir(output_filepath)
-    rows = []  
+  if format == 'csv':
+    if output_filepath.endswith('.parquet'):
+      output_filepath = output_filepath[:-8]
+    if not output_filepath.endswith('.csv'):
+      output_filepath += '.csv'
+    
+  parquet_count = 0
+  rows = []
   
   inference_ds = get_inference_dataset(embeddings_ds, model)
 
@@ -229,7 +234,7 @@ def write_inference_file(
           continue
         if threshold is None or ex['logits'][t, i] > threshold[label]:
           offset = ex['timestamp_s'] + t * embedding_hop_size_s
-          logit = '{:.2f}'.format(ex['logits'][t, i])
+          logit = ex['logits'][t, i]
           if format == 'parquet':
             row = {
               headers[0]: ex["filename"].decode("utf-8"),
@@ -248,7 +253,7 @@ def write_inference_file(
                 ex['filename'].decode('utf-8'),
                 '{:.2f}'.format(offset),
                 label,
-                logit,
+                '{:.2f}'.format(logit),
             ]
             f.write(','.join(row) + '\n')
           detection_count += 1

--- a/chirp/inference/classify/classify.py
+++ b/chirp/inference/classify/classify.py
@@ -282,3 +282,5 @@ def write_inference_parquet(
             tmp_df = pd.DataFrame()
         else:
           nondetection_count += 1
+  print('\n\n\n   Detection count: ', detection_count)
+  print('NonDetection count: ', nondetection_count)

--- a/chirp/inference/classify/classify.py
+++ b/chirp/inference/classify/classify.py
@@ -238,7 +238,7 @@ def write_inference_parquet(
 ):
   """Write a Parquet file of inference results.
 
-  Uses Polars to write to a partitioned Parquet file.
+  Uses Pandas to write to a partitioned Parquet file.
   Each partition has a maximum of `row_size` rows.
   Setting `row_size` too large will result in too few partitions
   and may cause memory issues. Setting `row_size` too small will

--- a/chirp/inference/classify/classify.py
+++ b/chirp/inference/classify/classify.py
@@ -206,7 +206,6 @@ def write_inference_file(
     if not output_filepath.endswith('.parquet'):
       output_filepath += '.parquet'
     
-    tmp_df = pd.DataFrame()
     parquet_count = 0
     os.mkdir(output_filepath)
     rows = []  
@@ -243,7 +242,7 @@ def write_inference_file(
               tmp_df = pd.DataFrame(rows)
               tmp_df.to_parquet(f'{output_filepath}/part.{parquet_count}.parquet')
               parquet_count += 1
-              tmp_df = pd.DataFrame()
+              rows = []
           elif format == 'csv':
             row = [
                 ex['filename'].decode('utf-8'),
@@ -255,6 +254,7 @@ def write_inference_file(
           detection_count += 1
         else:
           nondetection_count += 1
+  # write remaining rows if parquet format
   if format == 'parquet' and rows:
     tmp_df = pd.DataFrame(rows)
     tmp_df.to_parquet(f'{output_filepath}/part.{parquet_count}.parquet')

--- a/chirp/inference/tests/classify_test.py
+++ b/chirp/inference/tests/classify_test.py
@@ -143,7 +143,7 @@ class ClassifyTest(parameterized.TestCase):
     )
     
     # make a fake embeddings dataset
-    filenames = [f'file_{i}' for i in range(100)]
+    filenames = [f'file_{i}' for i in range(101)]
     
     self.write_random_embeddings(embedding_dim, filenames, tempdir)
     
@@ -158,8 +158,7 @@ class ClassifyTest(parameterized.TestCase):
         labels=classes,
         output_filepath=parquet_path,
         embedding_hop_size_s=5.0,
-        row_size=10,
-        format='parquet',
+        shard_size=10,
     )
     
     classify.write_inference_file(
@@ -168,7 +167,7 @@ class ClassifyTest(parameterized.TestCase):
       labels=classes,
       output_filepath=csv_path,
       embedding_hop_size_s=5.0,
-      format='csv',
+      shard_size=10,
     )
     
     parquet = pd.read_parquet(parquet_path)


### PR DESCRIPTION
Right now, the file sizes are giant when writing the output from the classifier to a csv. However, Parquet reduces this file size significantly (in our case, we saw files go from ~80GB to ~3GB due to the number of duplicate filenames). 

By writing to a partitioned Parquet file, we can get small files and reduce the amount of memory needed. 