### PR TITLE
Clarify chirp/eval/ folder as retrieval-based eval for BIRB

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,17 +51,7 @@ Code: See [call_density.py](https://github.com/google-research/perch/blob/main/c
 
 We produced a benchmark paper for understanding model generalization when transferring from focal to passive acoustic datasets. The preprint is [available here](https://arxiv.org/abs/2312.07439).
 
-For details on setting up the benchmark and evaluation protocol, please refer to this [brief readme](https://docs.google.com/document/d/1RasVkxIKKlUToFlJ8gZxaHqIE-mMy9G1MZwfK98Gb-I) with instructions. The evaluation codebase is in [perch/chirp/eval](https://github.com/google-research/perch/tree/main/chirp/eval).
-
-To build the BIRB evaluation data, after [installing](#installation) the `chirp` package, run the following command from the repository's root directory:
-
-```bash
-poetry run tfds build -i chirp.data.bird_taxonomy,chirp.data.soundscapes \
-    soundscapes/{ssw,hawaii,coffee_farms,sierras_kahl,high_sierras,peru}_full_length \
-    bird_taxonomy/{downstream_full_length,class_representatives_slice_peaked}
-```
-
-The process should take 36 to 48 hours to complete and use around 256 GiB of disk space.
+More info at [perch/chirp/eval/README.md](https://github.com/google-research/perch/tree/main/chirp/eval/README.md).
 
 
 ### Source-Free Domain Adaptation and NOTELA

--- a/chirp/eval/README.md
+++ b/chirp/eval/README.md
@@ -1,0 +1,44 @@
+# BIRB Evaluation
+
+This folder contains the evaluation framework for the BIRB benchmark retrieval task.
+(This is NOT the script to generate classification metrics.)
+
+For details on setting up the benchmark and evaluation protocol, please refer to this [brief readme](https://docs.google.com/document/d/1RasVkxIKKlUToFlJ8gZxaHqIE-mMy9G1MZwfK98Gb-I) with instructions.
+
+To build the BIRB evaluation data, after [installing](../../README.md#installation) the `chirp` package, run the following command from the repository's root directory:
+
+```bash
+poetry run tfds build -i chirp.data.bird_taxonomy,chirp.data.soundscapes \
+    soundscapes/{ssw,hawaii,coffee_farms,sierras_kahl,high_sierras,peru}_full_length \
+    bird_taxonomy/{downstream_full_length,class_representatives_slice_peaked}
+```
+
+The process should take 36 to 48 hours to complete and use around 256 GiB of disk space.
+
+## Running eval.py
+
+The evaluation script requires a config file that specifies the model, datasets, and evaluation parameters.
+
+Run the script using:
+
+    poetry run python birb/eval/eval.py -- --config=<PATH_TO_EVAL_CONFIG_FILE>
+
+
+### Required Config Settings
+
+[Read what your config must specify.](https://docs.google.com/document/d/1RasVkxIKKlUToFlJ8gZxaHqIE-mMy9G1MZwfK98Gb-I)
+
+### Outputs
+
+After executing the evaluation pipeline, output evaluation metrics for each
+species results are written:
+
+* `eval_species`: Species identifier
+* `average_precision`: AP score
+* `roc_auc`: ROC AUC score
+* `num_pos_match`: Number of positive matches
+* `num_neg_match`: Number of negative matches
+* `eval_set_name`: Name of evaluation dataset
+
+Results are written to the path specified by `config.write_results_dir`,
+in CSV format.

--- a/chirp/eval/eval.py
+++ b/chirp/eval/eval.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Evaluate a trained model."""
+"""Evaluate a trained model's embeddings on BIRB retrieval task."""
 
 from collections.abc import Sequence
 import os

--- a/chirp/eval/eval_lib.py
+++ b/chirp/eval/eval_lib.py
@@ -599,26 +599,38 @@ def _create_embeddings_dataframe(
 def prepare_eval_sets(
     config: ConfigDict, embedded_datasets: dict[str, tf.data.Dataset]
 ) -> Iterator[EvalSet]:
-  """Constructs and yields eval sets.
+  """Constructs and yields eval sets for the BIRB retrieval task.
+
+  For each class, we select some examples as "queries" and then test if the model can find other
+  recordings of that same class in the larger search corpus.
+
+  This function takes embedded audio datasets and organizes them into evaluation sets
+  where we can test how well the model recognizes specific classes. For each
+  evaluation set, it:
+  1. Creates a search corpus - the full set of audio examples to search through
+  2. For each class, selects representative examples and marks which examples
+     in the search corpus should be excluded for fair evaluation
 
   Args:
     config: The evaluation configuration dict.
     embedded_datasets: A mapping from dataset name to embedded dataset.
 
   Yields:
-    A tuple of (eval_set_name, search_corpus_df, classwise_eval_set_generator).
-    The classwise eval set generator itself yields (class_name,
-    class_representatives_df, search_corpus_mask) tuples. Each search corpus
-    mask indicates which part of the search corpus should be ignored in the
-    context of its corresponding class (e.g., because it overlaps with the
-    chosen class representatives). The DataFrame (`*_df`) objects have the
-    following columns:
-    - embedding: numpy array of dtype float32.
-    - label: space-separated string of foreground labels.
-    - bg_labels: space-separated string of background labels.
-    - dataset_name: name of the dataset of origin for the embedding.
-    - recording_id: integer recording ID.
-    - segment_id: integer segment ID within the recording.
+    An EvalSet tuple of (eval_set_name, search_corpus_df, classwise_eval_set_generator).
+    - eval_set_name: Name of this evaluation set, from the config.
+    - search_corpus_df: DataFrame of all audio examples, with columns:
+        - embedding: numpy array of dtype float32.
+        - label: space-separated string of foreground labels.
+        - bg_labels: space-separated string of background labels.
+        - dataset_name: name of the dataset of origin for the embedding.
+        - recording_id: integer recording ID.
+        - segment_id: integer segment ID within the recording.
+    - classwise_eval_sets: Generator that yields tuples containing:
+        - class_name,
+        - class_representatives_df: Representative examples of that class
+        - search_corpus_mask: Mask indicating which part of the search corpus
+             should be ignored in the context of its corresponding class (e.g.,
+             because it overlaps with the chosen class representatives)
   """
   # Add a 'dataset_name' feature to all embedded datasets.
   embedded_datasets = {


### PR DESCRIPTION
I began looking at `chirp/eval/` for classification task evaluation but discovered that's not what this is.  This PR adds some documentation to set me straight sooner next time :-)